### PR TITLE
Mount the whole workspace in the container

### DIFF
--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -9,5 +9,5 @@ docker run \
     -e USER=${USER} \
     -e USERID=$(grep Uid /proc/self/status | cut -f2 | awk '{$1=$1};1') \
     -u $(id -u) \
-    -v $(pwd)/dist:/src/dist \
+    -v $(pwd):/src \
     linode-cli-$BUILD_TAG


### PR DESCRIPTION
Since `cibuild.sh`  runs as the jenkins user but the files in the container image are owned by `root`, we get permissions errors when the script tries to create files during the build process. To fix, just mount the entire jenkins workspace into the container,  since those files are owned by the Jenkins user.